### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "babel-polyfill": "^6.13.0",
     "lodash": "^4.14.2",
     "moment": "^2.14.1",
-    "node-uuid": "^1.4.7",
     "request": "^2.74.0",
     "request-debug": "^0.2.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "uuid": "^3.0.0"
   },
   "ava": {
     "files": [

--- a/src/smsers/dahansantong.js
+++ b/src/smsers/dahansantong.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import SmserAbstract from './abstract';
 import { md5 } from '../utils';
 import SmsResponse from '../sms_response';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.